### PR TITLE
enable debug status for contest required

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -16,6 +16,11 @@ App({
       })
     }
 
+    // 打开调试开关
+    wx.setEnableDebug({
+      enableDebug: true
+    })
+
     // openid在后台获取并在加载小程序时从后台返回
     this.globalData = {
       openid: '',


### PR DESCRIPTION
因为域名备案问题，或者是没有资质需要走体验版流程评审的同学记得主动调用一下这个API，这样可以省去评委在体验的过程中多了一步打开调试。